### PR TITLE
allow to specify ssh port via command line

### DIFF
--- a/check_sshfp
+++ b/check_sshfp
@@ -47,7 +47,7 @@ SSHFP_FP_ALGS = {
 }
 
 
-def check_sshfp_for_host(hostname):
+def check_sshfp_for_host(hostname, port='22'):
 
     # First, get the SSHFPs.
     sshfp_result = dns.resolver.query(hostname, dns.rdatatype.SSHFP, raise_on_no_answer=False)
@@ -66,7 +66,7 @@ def check_sshfp_for_host(hostname):
     # passed through on stderr... and keys (on stdout) might be big,
     # so we might deadlock if we read all the way through one stdio
     # stream without also reading the other simultaneously... DansGame.
-    subproc = subprocess.Popen(['ssh-keyscan', '-t', 'rsa,dsa,ecdsa,ed25519', hostname], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subproc = subprocess.Popen(['ssh-keyscan', '-t', 'rsa,dsa,ecdsa,ed25519', '-p', port, hostname], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = subproc.communicate()
     cleaned_stderr = '\n'.join(line for line in stderr.decode().splitlines() if not line.startswith('#'))
     # It can also return 0 even if there were critical problems
@@ -106,7 +106,13 @@ def check_sshfp_for_host(hostname):
 if __name__ == '__main__':
     # Turn exceptions into UNKNOWN.
     try:
-        check_sshfp_for_host(sys.argv[1])
+        if len(sys.argv) == 2:
+            check_sshfp_for_host(sys.argv[1])
+        elif len(sys.argv) == 3:
+            check_sshfp_for_host(sys.argv[1], sys.argv[2])
+        else:
+            print('Usage: %s HOSTNAME [PORT]' % (sys.argv[0],))
+            sys.exit(3)
     except Exception:
         sys.stdout.write('SSHFP UNKNOWN: ' + traceback.format_exc())
         sys.exit(3)


### PR DESCRIPTION
ssh-keyscan is being used for retrieving ssh fingerprints for hosts on
the default port 22. This commit extends check_sshfs to be called with
an optional argument to specify which port ssh-keyscan should connect
to.

New usage:

check_sshfp HOSTNAME [PORT]